### PR TITLE
arrow functions aren't practical with any of the normal eslint rules, turn off

### DIFF
--- a/rules/ecmascript-6.js
+++ b/rules/ecmascript-6.js
@@ -2,10 +2,7 @@
 
 module.exports = {
 	rules: {
-		'arrow-body-style': [
-			'error',
-			'always'
-		],
+		'arrow-body-style': 'off',
 		'arrow-parens': 'error',
 		'arrow-spacing': 'error',
 		'constructor-super': 'error',


### PR DESCRIPTION
The current `arrow-body-style` eslint rule uses the default `always` with `error` but that would require the following:

```
list.every((x) => typeof x.id === 'number')
```

be converted into

```
list.every((x) => {
    return typeof x.id === 'number';
})
```

Which makes the code harder to read and longer. Simple chains become nasty.

The `arrow-body-style` supports an `as-needed` value but this also causes ugliness.

The rule would insist that

```
.filter((lambdaName) => {
    return lambdaName.indexOf(matchPrepend) === 0
        && exceptionList.indexOf(lambdaName) === -1
    ;
})
```

be converted into something like

```
.filter((lambdaName) => lambdaName.indexOf(matchPrepend) === 0 && exceptionList.indexOf(lambdaName) === -1)
```

which is just way too long a line, or trying to break the line up we get

```
.filter((lambdaName) =>
    lambdaName.indexOf(matchPrepend) === 0
    && exceptionList.indexOf(lambdaName) === -1
)
```

but that looks like a block of code and has the reader wondering why there isn't a return.

Perhaps the last example is acceptable and `as-needed` is the better setting for `arrow-body-style` once coders get used to it, but certainly `always` shows a pretty narrow imagination, and misses the potential of arrow functions to clean up code style.