### PR TITLE
Default chain depth of 2 is ok but 4 is better, for sure at least 3

### DIFF
--- a/rules/stylistic-issues.js
+++ b/rules/stylistic-issues.js
@@ -56,7 +56,10 @@ module.exports = {
 		'new-parens': 'error',
 		'newline-after-var': 'off',
 		'newline-before-return': 'off',
-		'newline-per-chained-call': 'error',
+		'newline-per-chained-call': [
+			'error',
+			{ignoreChainWithDepth: 4}
+		],
 		'no-array-constructor': 'error',
 		'no-bitwise': 'error',
 		'no-continue': 'off',


### PR DESCRIPTION
```
const noExt = config.handler.split('.').slice(0, -1).join('.');
```

nothing wrong with that except that the default `ignoreChainWithDepth` of 2 doesn't allow it.