### PR TITLE
Relax no-unused-expressions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Change Log
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
+The format conforms to [Keep a Changelog](http://keepachangelog.com/).
+
+## [Unreleased]
+### Changed
+- Allow `allowShortCircuit` and `allowTernary` for `no-unused-expressions`
 
 ## [1.1.0] - 2016-06-17
 ### Changed
@@ -11,4 +16,5 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 - Initial rule set
 
+[Unreleased]: https://github.com/CoursePark/NestHydrationJS/compare/v1.1.0...HEAD
 [1.1.0]: https://github.com/CoursePark/NestHydrationJS/compare/v1.0.0...v1.1.0

--- a/rules/best-practices.js
+++ b/rules/best-practices.js
@@ -68,7 +68,13 @@ module.exports = {
 		'no-sequences': 'error',
 		'no-throw-literal': 'error',
 		'no-unmodified-loop-condition': 'error',
-		'no-unused-expressions': 'error',
+		'no-unused-expressions': [
+			'error',
+			{
+				allowShortCircuit: true,
+				allowTernary: true
+			}
+		],
 		'no-unused-labels': 'error',
 		'no-useless-call': 'error',
 		'no-useless-concat': 'error',


### PR DESCRIPTION
Allow constructs such as:

    endpoint.shutdown && endpoint.shutdown();

and

    endpoint.shutdown ? endpoint.shutdown() : null; 