### PR TITLE
Don't enforce valid JSDoc comments

### DIFF
--- a/rules/possible-errors.js
+++ b/rules/possible-errors.js
@@ -39,7 +39,7 @@ module.exports = {
 		'no-unsafe-finally': 'error',
 		'no-unsafe-negation': 'error',
 		'use-isnan': 'error',
-		'valid-jsdoc': 'warn',
+		'valid-jsdoc': 'off',
 		'valid-typeof': 'error',
 	},
 };


### PR DESCRIPTION
This PR disables the `valid-jsdoc` rule, no longer enforcing that JSDoc comments are valid.

The idea of the rule is useful, but it doesn't allow for some of the more complicated types, as "JSDoc only supports Closure Compiler type expressions, not Flow or TypeScript type expressions."<sup>[\[1\]](https://github.com/jsdoc3/jsdoc/issues/1285#issuecomment-279897531)</sup> An example of **incorrect** code for this rule (despite being valid JSDoc, just with a "unsupported" type expression):

```javascript
/**
 * Configures and returns the redux store and history
 * @param {object} config the application config
 * @return {{history: History & HistoryUnsubscribe, store: Store<any>}} the redux store and history
 */
```

I think it's important to keep using JSDoc even with "unsupported" type expressions (as long as whatever tooling understands it) and this warning makes it a touch annoying. The alternative would be to have this rule disabled in particular projects where the tooling allows for it.