### PR TITLE
Apply the same filename rules to Jest as we do React

### DIFF
--- a/jest.js
+++ b/jest.js
@@ -11,4 +11,10 @@ module.exports = {
 		'./index',
 		'./rules/plugin-jest',
 	].map(require.resolve),
+	rules: {
+		'filenames/match-regex': [
+			'error',
+			/^[A-Za-z0-9.-]+$/,
+		],
+	},
 };


### PR DESCRIPTION
This PR updates the `filenames/match-regex` rule for Jest (sub)projects to use the same RegEx as React does.

Since Jest is oft (if not always) used alongside React, the `filenames/match-regex` rule will need to allow the same file names as are valid in React (sub)projects. A common project setup is to use `src/` and `test/` at the same level with the same directory structure, e.g.

```
.
├── src
│   ├── index.js
│   ├── lib
│   │   └── stateValues.js
│   └── pages
│       └── Login
│           └── LoginPage.js
├── test
│   ├── .eslintrc.js
│   ├── lib
│   │   └── stateValues.js
│   └── pages
│       └── LoginPage.js
└── package.json
```

With the `bluedrop/react` config enabled for the `src/` directory and the `bluedrop/jest` config enabled for the `test/` directory the same file names aren't allowed.