### PR TITLE
Disable require-await

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,12 @@ An extension of `eslint-config-bluedrop` that adds support for ECMAScript 8.
 1. Ensure you have installed the dependencies from General Setup
 1. Add `"extends": "bluedrop/ecmascript-8"` to your ESLint config file
 
+## Versioning
+
+This project follows [Semantic Versioning](http://semver.org/) as closely as possible. A MAJOR change would be caused
+by including a rule that could cause a passing code base to fail. A MINOR change is a modification or removal of a rule
+that would not cause existing passing code to fail. A PATCH would be any fix that doesn't cause any changes to rules.
+
 ## Contributing
 
 Add new rule definitions under the files located in `rules` ensuring to keep the rule correctly categorized and in the

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-bluedrop",
-  "version": "3.1.0",
+  "version": "3.3.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-bluedrop",
-  "version": "3.2.0",
+  "version": "3.3.0",
   "description": "Bluedrop's ESLint configurations",
   "main": "index.js",
   "scripts": {

--- a/rules/best-practices.js
+++ b/rules/best-practices.js
@@ -99,7 +99,7 @@ module.exports = {
 		'no-with': 'error',
 		'prefer-promise-reject-errors': 'error',
 		radix: 'error',
-		'require-await': 'error',
+		'require-await': 'off',
 		'vars-on-top': 'error',
 		'wrap-iife': 'error',
 		yoda: 'off',


### PR DESCRIPTION
This code is flagged as an error, but would be a common usage for us:

```
module.exports = () => {
	return {
		async find(params) {
			return {
				isAuthenticated: Boolean(params.user),
				datetime: new Date(),
			};
		},
	};
};
```