### PR TITLE
Relax no-unused-vars options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [7.1.0] - 2019-08-30
+### Changed
+- Add `ignoreRestSiblings` and `argsIgnorePattern` for `no-unused-vars` rule
+
 ## [7.0.0] - 2019-08-27
 ### Added
 - New rules since last major release

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-bluedrop",
-  "version": "7.0.0",
+  "version": "7.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-bluedrop",
-  "version": "7.0.0",
+  "version": "7.1.0",
   "description": "Bluedrop's ESLint configurations",
   "main": "config/common.js",
   "files": [

--- a/rules/variables.js
+++ b/rules/variables.js
@@ -16,7 +16,12 @@ module.exports = {
 		'no-undef': 'error',
 		'no-undef-init': 'error',
 		'no-undefined': 'off',
-		'no-unused-vars': 'error',
+		'no-unused-vars': [
+			'error', {
+				ignoreRestSiblings: true,
+				argsIgnorePattern: '^_',
+			},
+		],
 		'no-use-before-define': 'error',
 	},
 };


### PR DESCRIPTION
Add `ignoreRestSiblings` and `argsIgnorePattern` for `no-unused-vars` rule.

`ignoreRestSiblings` allows unused siblings when using object rest. This is useful to exclude properties from a remaining spread.

`argsIgnorePattern` isn't really something we need at the moment, but allows unused parameters assuming that they begin with an `_`.
